### PR TITLE
Updated pyOCD command line a.o.

### DIFF
--- a/.github/workflows/Run_CMSIS_DV.yaml
+++ b/.github/workflows/Run_CMSIS_DV.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Download Build Artifact
-      uses: dawidd6/action-download-artifact@v16
+      uses: dawidd6/action-download-artifact@v19
       with:
         workflow: Build_CMSIS_DV.yaml
         name: CMSIS_Driver_Validation@Release
@@ -37,4 +37,4 @@ jobs:
     - name: Execute the CMSIS_Driver_Validation@Release
       working-directory: ./Test/artifact
       run: | 
-         pyocd load --probe cmsisdap: --cbuild-run CMSIS_DV+T2G-Kit.cbuild-run.yml
+         pyocd load --uid 171C089E02272400 --cbuild-run CMSIS_DV+T2G-Kit.cbuild-run.yml


### PR DESCRIPTION
- Replace the --probe cmsisdap: with --uid 171C089E02272400 in the pyOCD command line to solve the issue More than one debug probe matches unique ID cmsisdap: . 

- Updated GHA dawidd6/action-download-artifact to version 19.